### PR TITLE
Avoid explicitly setting the ToC with each section

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -7,6 +7,32 @@
 
 \usetheme{CERN}
 
+%
+\newcommand{\interludeTitle}{We are here!}
+\AtBeginSection[] {
+    \frame{
+	\frametitle{\interludeTitle}
+      \begin{multicols}{2}
+        \tableofcontents[
+            currentsection,
+            sectionstyle=show/shaded,
+            ]
+	  \end{multicols}
+    }
+}
+
+\AtBeginSubsection[] {
+	  \frame{
+		\frametitle{\interludeTitle}
+		\begin{multicols}{2}
+        \tableofcontents[
+            currentsubsection,
+            subsectionstyle=show/shaded,
+            ]
+		\end{multicols}
+	  }
+}
+
 % Preamble
 \title[]{Stuff we want to talk about}
 \author[A.u.thor]{Guy talking about the stuff \newline \texttt{author@email}}
@@ -36,15 +62,6 @@
 
 
     \section{Introduction}
-    \frame{
-        \frametitle{Table of Contents}
-        \begin{multicols}{2}
-        \tableofcontents[
-            currentsection,
-            sectionstyle=show/shaded,
-            ]
-        \end{multicols}
-    }
 
     \frame{
         \frametitle{This is the first slide}
@@ -68,15 +85,6 @@
     }
     
     \section{Section 1}
-    \frame{
-        \frametitle{Table of Contents}
-        \begin{multicols}{2}
-        \tableofcontents[
-            currentsection,
-            sectionstyle=show/shaded,
-            ]
-        \end{multicols}
-    }
 
     \frame{
         \frametitle{Generic slide}
@@ -84,15 +92,7 @@
         %More content goes here
     }
     \section{Section 2}
-    \frame{
-        \frametitle{Table of Contents}
-        \begin{multicols}{2}
-        \tableofcontents[
-            currentsection,
-            sectionstyle=show/shaded,
-            ]
-        \end{multicols}
-    }
+
     \frame{
         \frametitle{Generic slide}
         \framesubtitle{A bit more information about this}
@@ -101,15 +101,6 @@
 
     
     \section{Conclusion}
-    \frame{
-        \frametitle{Table of Contents}
-        \begin{multicols}{2}
-        \tableofcontents[
-            currentsection,
-            sectionstyle=show/shaded,
-            ]
-        \end{multicols}
-    }
     
     \frame{
         \frametitle{Generic slide}
@@ -118,15 +109,7 @@
     }
     
     \section{Acknowledgements}
-    \frame{
-        \frametitle{Table of Contents}
-        \begin{multicols}{2}
-        \tableofcontents[
-            currentsection,
-            sectionstyle=show/shaded,
-            ]
-        \end{multicols}
-    }
+    
     \frame{
         \frametitle{Generic slide}
         \framesubtitle{A bit more information about this}


### PR DESCRIPTION
Instead of explicitly including a frame with the current ToC in each section, you can set it to appear at the beginning of a section/subsection with the "AtBeginSection" and "AtBeginSubsection".
